### PR TITLE
feat: 로그인 경로 분리 및 AOP 권한 체크 개선

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,12 @@
 			<artifactId>jackson-databind</artifactId>
 		</dependency>
 
+		<!-- AOP -->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-aop</artifactId>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.springframework.data</groupId>

--- a/src/main/java/shop/chaekmate/front/auth/adaptor/AuthAdaptor.java
+++ b/src/main/java/shop/chaekmate/front/auth/adaptor/AuthAdaptor.java
@@ -17,6 +17,9 @@ public interface AuthAdaptor {
     @PostMapping("/auth/login")
     ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request);
 
+    @PostMapping("/auth/admin/login")
+    ResponseEntity<LoginResponse> adminLogin(@RequestBody LoginRequest request);
+
     @GetMapping("/auth/me")
     ResponseEntity<MemberInfoResponse> getMemberInfo(
             @CookieValue("accessToken") String token

--- a/src/main/java/shop/chaekmate/front/auth/config/SecurityConfig.java
+++ b/src/main/java/shop/chaekmate/front/auth/config/SecurityConfig.java
@@ -28,12 +28,23 @@ public class SecurityConfig {
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
+                        // 관리자 로그인 페이지는 누구나 접근 가능
+                        .requestMatchers("/admin/login").permitAll()
+                        // 관리자 페이지는 ADMIN 권한 필요
                         .requestMatchers("/admin/**").hasRole("ADMIN")
-                        .requestMatchers("/","/login", "/signup").permitAll()
-                        .requestMatchers("/css/**", "/js/**", "/img/**", "/lib/**", "/favicon.ico").permitAll()
-                        .requestMatchers("/logout").authenticated()
-                        .anyRequest().authenticated()
-                )
+                        // 비회원도 접근 되는 곳들
+                        .requestMatchers("/", "/login", "/signup").permitAll()
+                        .requestMatchers("/books/**").permitAll() // 도서 상세, 도서 목록
+                        .requestMatchers("/categories/**").permitAll() // 카테고리별 도서 목록
+                        .requestMatchers("/payments/**").permitAll() // 결제 페이지
+                        .requestMatchers("/css/**", "/js/**", "/img/**", "/lib/**",
+                                "/favicon.ico")
+                        .permitAll()
+                        // 회원 전용
+                        .requestMatchers("/mypage/**", "/logout").authenticated()
+                        .requestMatchers("/order").authenticated() // 주문 페이지
+                        // 나머지는 인증 필요
+                        .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(
                                 (request, response, authException) -> response.sendRedirect("/login")))

--- a/src/main/java/shop/chaekmate/front/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/shop/chaekmate/front/auth/filter/JwtAuthenticationFilter.java
@@ -18,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import shop.chaekmate.front.auth.dto.response.MemberInfoResponse;
 import shop.chaekmate.front.auth.principal.CustomPrincipal;
 import shop.chaekmate.front.auth.service.AuthService;
+import shop.chaekmate.front.auth.util.CookieUtil;
 
 @Component
 @RequiredArgsConstructor
@@ -30,7 +31,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
 
-        String accessToken = getTokenFromCookie(request);
+        String accessToken = CookieUtil.extractAccessTokenFromCookie(request);
 
         if (accessToken != null) {
             try {
@@ -66,19 +67,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         filterChain.doFilter(request, response);
-    }
-
-    private String getTokenFromCookie(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies == null) {
-            return null;
-        }
-
-        for (Cookie cookie : cookies) {
-            if ("accessToken".equals(cookie.getName())) {
-                return cookie.getValue();
-            }
-        }
-        return null;
     }
 }

--- a/src/main/java/shop/chaekmate/front/auth/handler/CustomLogoutHandler.java
+++ b/src/main/java/shop/chaekmate/front/auth/handler/CustomLogoutHandler.java
@@ -12,6 +12,7 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Component;
 import shop.chaekmate.front.auth.config.CookieConfig;
 import shop.chaekmate.front.auth.service.AuthService;
+import shop.chaekmate.front.auth.util.CookieUtil;
 
 @Slf4j
 @Component
@@ -23,17 +24,7 @@ public class CustomLogoutHandler implements LogoutHandler {
 
     @Override
     public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-        String accessToken = null;
-
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if ("accessToken".equals(cookie.getName())) {
-                    accessToken = cookie.getValue();
-                    break;
-                }
-            }
-        }
+        String accessToken = CookieUtil.extractAccessTokenFromCookie(request);
 
         // Auth Server에 logout 요청 (Redis에서 RefreshToken 삭제)
         if (accessToken != null && !accessToken.trim().isEmpty()) {

--- a/src/main/java/shop/chaekmate/front/auth/service/AuthService.java
+++ b/src/main/java/shop/chaekmate/front/auth/service/AuthService.java
@@ -19,6 +19,10 @@ public class AuthService {
         return authAdaptor.login(request);
     }
 
+    public ResponseEntity<LoginResponse> adminLogin(LoginRequest request) {
+        return authAdaptor.adminLogin(request);
+    }
+
     public ResponseEntity<MemberInfoResponse> getMemberInfo(String token) {
         return authAdaptor.getMemberInfo(token);
     }

--- a/src/main/java/shop/chaekmate/front/auth/util/CookieUtil.java
+++ b/src/main/java/shop/chaekmate/front/auth/util/CookieUtil.java
@@ -1,0 +1,28 @@
+package shop.chaekmate.front.auth.util;
+
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+
+public class CookieUtil {
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+
+    // HttpServletRequest에서 accessToken을 추출함
+    public static String extractAccessTokenFromCookie(HttpServletRequest request) {
+        if(request == null) {
+            return null;
+        }
+        Cookie[] cookies = request.getCookies();
+        if(cookies == null) {
+            return null;
+        }
+
+        for(Cookie cookie : cookies) {
+            if(ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())){
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko"
+      th:replace="~{layout/layout :: html(~{::section})}">
+<section>
+
+    <div class="container-fluid">
+        <div class="row px-xl-5">
+            <div class="col-lg-8 mb-5 mx-auto">
+                <div class="bg-light p-30">
+                    <h2 class="mb-4">로그인</h2>
+                    <form th:action="@{/admin/login}" method="post">
+                        <div class="row">
+                            <div class="col-md-12 form-group">
+                                <label for="loginId">Login ID</label>
+                                <input type="text" class="form-control" id="loginId" name="loginId" required>
+                            </div>
+                            <div class="col-md-12 form-group">
+                                <label for="password">Password</label>
+                                <input type="password" class="form-control" id="password" name="password" required>
+                            </div>
+                            <div th:if="${error}" class="col-md-12">
+                                <div class="text-danger" style="font-size: 14px; margin-bottom: 10px;">
+                                    <span th:text="${error}"></span>
+                                </div>
+                            </div>
+                            <div class="col-md-12">
+                                <button type="submit" class="btn btn-primary">Login</button>
+                            </div>
+                            <div class="col-md-12 mt-3 text-center">
+                                <span>계정이 없으신가요? </span>
+                                <a href="/signup" class="text-primary">회원가입</a>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+</section>
+</html>
+

--- a/src/test/java/shop/chaekmate/front/auth/SecurityContextHolderTest.java
+++ b/src/test/java/shop/chaekmate/front/auth/SecurityContextHolderTest.java
@@ -1,0 +1,93 @@
+package shop.chaekmate.front.auth;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import shop.chaekmate.front.auth.principal.CustomPrincipal;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class SecurityContextHolderTest {
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void SecurityContextHolder에_CustomPrincipal_저장_및_조회_성공() {
+        Long memberId = 1L;
+        String name = "테스트사용자";
+        String role = "ADMIN";
+        CustomPrincipal principal = new CustomPrincipal(memberId, name, role);
+        List<SimpleGrantedAuthority> authorities = List.of(
+                new SimpleGrantedAuthority("ROLE_" + role));
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                authorities);
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Authentication retrievedAuth = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(retrievedAuth).isNotNull();
+        assertThat(retrievedAuth.isAuthenticated()).isTrue();
+
+        Object retrievedPrincipal = retrievedAuth.getPrincipal();
+        assertThat(retrievedPrincipal).isInstanceOf(CustomPrincipal.class);
+
+        CustomPrincipal retrievedCustomPrincipal = (CustomPrincipal) retrievedPrincipal;
+        assertThat(retrievedCustomPrincipal.getMemberId()).isEqualTo(memberId);
+        assertThat(retrievedCustomPrincipal.getName()).isEqualTo(name);
+        assertThat(retrievedCustomPrincipal.getRole()).isEqualTo(role);
+        assertThat(retrievedAuth.getAuthorities())
+                .hasSize(1)
+                .extracting("authority")
+                .contains("ROLE_ADMIN");
+    }
+
+    @Test
+    void AuthenticationPrincipal로_사용_가능한_형태인지_확인() {
+        CustomPrincipal principal = new CustomPrincipal(1L, "테스트사용자", "USER");
+        Authentication auth = new UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+
+        SecurityContextHolder.getContext().setAuthentication(auth);
+
+        Authentication retrievedAuth = SecurityContextHolder.getContext().getAuthentication();
+        CustomPrincipal retrievedPrincipal = (CustomPrincipal) retrievedAuth.getPrincipal();
+
+        assertThat(retrievedPrincipal).isNotNull();
+        assertThat(retrievedPrincipal.getMemberId()).isEqualTo(1L);
+        assertThat(retrievedPrincipal.getName()).isEqualTo("테스트사용자");
+        assertThat(retrievedPrincipal.getRole()).isEqualTo("USER");
+    }
+
+    @Test
+    void SecurityContextHolder가_비어있을_때_null_반환() {
+        SecurityContextHolder.clearContext();
+
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+        assertThat(auth).isNull();
+    }
+}

--- a/src/test/java/shop/chaekmate/front/auth/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/shop/chaekmate/front/auth/filter/JwtAuthenticationFilterTest.java
@@ -1,0 +1,137 @@
+package shop.chaekmate.front.auth.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.ActiveProfiles;
+import shop.chaekmate.front.auth.dto.response.MemberInfoResponse;
+import shop.chaekmate.front.auth.principal.CustomPrincipal;
+import shop.chaekmate.front.auth.service.AuthService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+
+@ActiveProfiles("test")
+@ExtendWith(MockitoExtension.class)
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock
+    private AuthService authService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @InjectMocks
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    void 쿠키에_accessToken이_있고_Auth_Server에서_사용자_정보를_성공적으로_받아오면_SecurityContextHolder에_저장() throws Exception {
+        String accessToken = "test-access-token";
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        Cookie[] cookies = { cookie };
+
+        MemberInfoResponse memberInfo = new MemberInfoResponse(1L, "테스트사용자", "ADMIN");
+        ResponseEntity<MemberInfoResponse> responseEntity = ResponseEntity.ok(memberInfo);
+
+        when(request.getCookies()).thenReturn(cookies);
+        when(authService.getMemberInfo(accessToken)).thenReturn(responseEntity);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNotNull();
+        assertThat(authentication.isAuthenticated()).isTrue();
+
+        CustomPrincipal principal = (CustomPrincipal) authentication.getPrincipal();
+        assertThat(principal.getMemberId()).isEqualTo(1L);
+        assertThat(principal.getName()).isEqualTo("테스트사용자");
+        assertThat(principal.getRole()).isEqualTo("ADMIN");
+
+        verify(authService).getMemberInfo(accessToken);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void 쿠키에_accessToken이_없으면_SecurityContextHolder에_저장하지_않음() throws Exception {
+        when(request.getCookies()).thenReturn(null);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNull();
+
+        verify(authService, never()).getMemberInfo(anyString());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void Auth_Server_호출_실패시_SecurityContextHolder_초기화() throws Exception {
+        String accessToken = "invalid-token";
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        Cookie[] cookies = { cookie };
+
+        when(request.getCookies()).thenReturn(cookies);
+        when(authService.getMemberInfo(accessToken)).thenThrow(new RuntimeException("Auth Server 오류"));
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNull();
+
+        verify(authService).getMemberInfo(accessToken);
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    void Auth_Server_응답이_200번대가_아니면_SecurityContextHolder에_저장하지_않음() throws Exception {
+        String accessToken = "test-token";
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        Cookie[] cookies = { cookie };
+
+        ResponseEntity<MemberInfoResponse> errorResponse = ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+
+        when(request.getCookies()).thenReturn(cookies);
+        when(authService.getMemberInfo(accessToken)).thenReturn(errorResponse);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        assertThat(authentication).isNull();
+
+        verify(authService).getMemberInfo(accessToken);
+        verify(filterChain).doFilter(request, response);
+    }
+}


### PR DESCRIPTION
## 🔥 연관 이슈

close: #

## 📝 작업 요약
일반 사용자 로그인(`/login`)과 관리자 로그인(`/admin/login`)을 경로로 분리하여 각각 Member 테이블과 Admin 테이블로 접근하도록 구현 및 Security Config파일 수정하여 경로 접근 제어 추가

## ⏰ 소요 시간
1일

## 🔎 작업 상세 설명
관리자 로그인 페이지 구현

- AuthController에 `/admin/login` GET/POST 엔드포인트 추가
- `admin/login.html` 템플릿 생성 (일반 로그인 페이지와 동일한 디자인)
- SecurityConfig에 경로 수정


## 🌟 논의 사항
각각 사용하시는 경로들이 다 다르실텐데 경로가 만약 다르다면 permialAll로 우선 허용해두시고 말씀해주시면 감사하겠습니다.