### PR TITLE
feat: 카테고리 캐싱 삭제/ 카테고리 호출 실패해도 실행되도록 수정

### DIFF
--- a/src/main/java/shop/chaekmate/front/category/cache/CategoryCache.java
+++ b/src/main/java/shop/chaekmate/front/category/cache/CategoryCache.java
@@ -1,30 +1,20 @@
 package shop.chaekmate.front.category.cache;
 
-import jakarta.annotation.PostConstruct;
+import java.util.Collections;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import shop.chaekmate.front.category.dto.response.CategoryResponse;
-import shop.chaekmate.front.category.service.CategoryService;
 
 @Component
-@RequiredArgsConstructor
 public class CategoryCache {
-
-    // 카테고리 캐싱
-    private final CategoryService categoryService;
-    private List<CategoryResponse> categories;
-
-    @PostConstruct
-    public void loadCategories() {
-        this.categories = categoryService.getCategories();
-    }
+    // 호출 실패 대비 저장용 캐시
+    private List<CategoryResponse> categories = Collections.emptyList();
 
     public List<CategoryResponse> getCachedCategories() {
         return categories;
     }
 
-    public void reload() { // 필요시 수동 리로드 가능
-        this.categories = categoryService.getCategories();
+    public void reload(List<CategoryResponse> newCategories) {
+        this.categories = newCategories;
     }
 }

--- a/src/main/java/shop/chaekmate/front/common/GlobalModelAttributeHandler.java
+++ b/src/main/java/shop/chaekmate/front/common/GlobalModelAttributeHandler.java
@@ -5,18 +5,20 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import shop.chaekmate.front.category.cache.CategoryCache;
 import shop.chaekmate.front.category.dto.response.CategoryResponse;
+import shop.chaekmate.front.category.service.CategoryService;
 
 @ControllerAdvice
 @RequiredArgsConstructor
 public class GlobalModelAttributeHandler {
     // 모든 페이지에서 카테고리들 주입
 
-    private final CategoryCache categoryCache; // 내부적으로 캐시 사용 중
+    private final CategoryService categoryService; // Service에서 캐시 관리
 
     @ModelAttribute("categories")
     public List<CategoryResponse> addCategoriesToModel() {
-        return categoryCache.getCachedCategories();
+        // Service가 캐시 확인 후 API 호출까지 알아서 처리
+        return categoryService.getCategories();
     }
+
 }


### PR DESCRIPTION
## 🔥 연관 이슈

close: #

## 📝 작업 요약

프론트 서버에서 캐싱하던 카테고리를 백엔드 에서 캐싱하도록 변경

프론트 서버 실행 시 카테고리 호출 실패하면 실행 실패하던 점 수정

## ⏰ 소요 시간

기능 구현에 소요된 시간을 적어주세요. (추정했던 시간과 다르다면 이유도 함께)

## 🔎 작업 상세 설명

주요 기능 및 로직에 관해 설명해주세요.

## 🌟 논의 사항

동료들과 이야기 해보고 싶은 부분을 적어주세요.
