### PR TITLE
장바구니 화면 리팩토링 V02

### DIFF
--- a/src/main/java/shop/chaekmate/front/cart/adaptor/CartAdaptor.java
+++ b/src/main/java/shop/chaekmate/front/cart/adaptor/CartAdaptor.java
@@ -7,6 +7,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import shop.chaekmate.front.auth.config.AuthFeignClientConfig;
 import shop.chaekmate.front.cart.dto.request.CartItemCreateRequest;
 import shop.chaekmate.front.cart.dto.request.CartItemUpdateRequest;
 import shop.chaekmate.front.cart.dto.response.CartItemListAdvancedResponse;
@@ -19,11 +21,12 @@ public interface CartAdaptor {
 
     // 장바구니 담기
     @PostMapping("/carts/items")
-    CommonResponse<CartItemListResponse> addCartItem(@RequestBody CartItemCreateRequest request);
+    CommonResponse<CartItemListResponse> addCartItem(@RequestBody CartItemCreateRequest request,
+                                                     @RequestHeader("cookie") String cookie);
 
     // 장바구니 조회
     @GetMapping("/carts")
-    CommonResponse<CartItemListAdvancedResponse> getCart();
+    CommonResponse<CartItemListAdvancedResponse> getCart(@RequestHeader("cookie") String cookie);
 
     // 장바구니 아이템 수량 변경
     @PutMapping("/carts/items/{bookId}")

--- a/src/main/java/shop/chaekmate/front/cart/controller/CartController.java
+++ b/src/main/java/shop/chaekmate/front/cart/controller/CartController.java
@@ -37,8 +37,8 @@ public class CartController {
                               HttpServletResponse response,
                               Model model) {
 
-        this.getOrCreateUuid(request, response);
-        CartItemListAdvancedResponse cart = this.cartService.getCart();
+        String guestId = this.getOrCreateUuid(request, response);
+        CartItemListAdvancedResponse cart = this.cartService.getCart(guestId);
         model.addAttribute("cart", cart);
         return "cart/cart";
     }
@@ -49,8 +49,9 @@ public class CartController {
     public CartItemListResponse addCartItem(HttpServletRequest request,
                                             HttpServletResponse response,
                                             @RequestBody CartItemCreateRequest cartItemCreateRequest) {
-        this.getOrCreateUuid(request, response);
-        return this.cartService.addCartItem(cartItemCreateRequest);
+
+        String guestId = this.getOrCreateUuid(request, response);
+        return this.cartService.addCartItem(cartItemCreateRequest, guestId);
     }
 
     // 장바구니 아이템 수량 변경
@@ -75,28 +76,31 @@ public class CartController {
         this.cartService.flushCart();
     }
 
-    private void getOrCreateUuid(HttpServletRequest request, HttpServletResponse response) {
-        boolean hasUuid = false;
+    // Guest-Id 가져오기 또는 생성
+    private String getOrCreateUuid(HttpServletRequest request, HttpServletResponse response) {
+        String guestId = null;
 
         // 1. 요청 쿠키에서 UUID 확인
         if (Objects.nonNull(request.getCookies())) {
             for (Cookie cookie : request.getCookies()) {
                 if (COOKIE_NAME.equals(cookie.getName())) {
-                    hasUuid = true;
+                    guestId = cookie.getValue();
                     break;
                 }
             }
         }
 
         // 2. 없으면 새 UUID 생성 및 쿠키에 추가
-        if (!hasUuid) {
-            String uuid = UUID.randomUUID().toString();
-            Cookie cookie = new Cookie(COOKIE_NAME, uuid);
+        if (Objects.isNull(guestId)) {
+            guestId = UUID.randomUUID().toString();
+            Cookie cookie = new Cookie(COOKIE_NAME, guestId);
             cookie.setPath("/");                    // 모든 경로에서 접근 가능
             cookie.setHttpOnly(true);               // JS 접근 차단
             cookie.setMaxAge(60 * 60 * 24 * 30);    // 30일
 
             response.addCookie(cookie);
         }
+
+        return guestId;
     }
 }

--- a/src/main/java/shop/chaekmate/front/cart/controller/CartController.java
+++ b/src/main/java/shop/chaekmate/front/cart/controller/CartController.java
@@ -22,6 +22,8 @@ import shop.chaekmate.front.cart.dto.response.CartItemListAdvancedResponse;
 import shop.chaekmate.front.cart.dto.response.CartItemListResponse;
 import shop.chaekmate.front.cart.dto.response.CartItemUpdateResponse;
 import shop.chaekmate.front.cart.service.CartService;
+import shop.chaekmate.front.order.adaptor.DeliveryPolicyAdaptor;
+import shop.chaekmate.front.order.dto.response.DeliveryPolicyResponse;
 
 @Controller
 @RequiredArgsConstructor
@@ -29,6 +31,8 @@ import shop.chaekmate.front.cart.service.CartService;
 public class CartController {
 
     private final CartService cartService;
+    private final DeliveryPolicyAdaptor deliveryPolicyAdaptor;
+
     private static final String COOKIE_NAME = "Guest-Id";
 
     // 장바구니 페이지 뷰
@@ -38,8 +42,13 @@ public class CartController {
                               Model model) {
 
         String guestId = this.getOrCreateUuid(request, response);
+
         CartItemListAdvancedResponse cart = this.cartService.getCart(guestId);
+        DeliveryPolicyResponse currentDelivery = this.deliveryPolicyAdaptor.getCurrentPolicy().data();
+
         model.addAttribute("cart", cart);
+        model.addAttribute("currentDelivery", currentDelivery);
+
         return "cart/cart";
     }
 
@@ -70,7 +79,7 @@ public class CartController {
     }
 
     // 장바구니 비우기
-    @DeleteMapping("/flush")
+    @PostMapping("/flush")
     @ResponseBody
     public void flushCart() {
         this.cartService.flushCart();

--- a/src/main/java/shop/chaekmate/front/cart/service/CartService.java
+++ b/src/main/java/shop/chaekmate/front/cart/service/CartService.java
@@ -21,11 +21,13 @@ import shop.chaekmate.front.common.CommonResponse;
 public class CartService {
 
     private final CartAdaptor cartAdaptor;
+    private static final String COOKIE_NAME = "Guest-Id";
 
     // 장바구니 아이템 추가
-    public CartItemListResponse addCartItem(CartItemCreateRequest request) {
+    public CartItemListResponse addCartItem(CartItemCreateRequest request, String guestId) {
         try {
-            CommonResponse<CartItemListResponse> response = this.cartAdaptor.addCartItem(request);
+            String cookieHeader = COOKIE_NAME + "=" + guestId;
+            CommonResponse<CartItemListResponse> response = this.cartAdaptor.addCartItem(request, cookieHeader);
             if (Objects.isNull(response) || Objects.isNull(response.data())) {
                 throw new CartException("장바구니 담기 결과가 없습니다.");
             }
@@ -37,9 +39,10 @@ public class CartService {
     }
 
     // 장바구니 조회
-    public CartItemListAdvancedResponse getCart() {
+    public CartItemListAdvancedResponse getCart(String guestId) {
         try {
-            CommonResponse<CartItemListAdvancedResponse> response = this.cartAdaptor.getCart();
+            String cookieHeader = COOKIE_NAME + "=" + guestId;
+            CommonResponse<CartItemListAdvancedResponse> response = this.cartAdaptor.getCart(cookieHeader);
 
             // API 응답이 없거나 data가 null인 경우
             if (Objects.isNull(response) || Objects.isNull(response.data())) {

--- a/src/main/java/shop/chaekmate/front/cart/service/CartService.java
+++ b/src/main/java/shop/chaekmate/front/cart/service/CartService.java
@@ -14,12 +14,14 @@ import shop.chaekmate.front.cart.dto.response.CartItemListResponse;
 import shop.chaekmate.front.cart.dto.response.CartItemUpdateResponse;
 import shop.chaekmate.front.cart.exception.CartException;
 import shop.chaekmate.front.common.CommonResponse;
+import shop.chaekmate.front.order.adaptor.DeliveryPolicyAdaptor;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class CartService {
 
+    private final DeliveryPolicyAdaptor deliveryPolicyAdaptor;
     private final CartAdaptor cartAdaptor;
     private static final String COOKIE_NAME = "Guest-Id";
 
@@ -95,6 +97,6 @@ public class CartService {
         } catch (FeignException e) {
             log.error("장바구니 비우기 실패: {}", e.getMessage(), e);
             throw new CartException("장바구니 비우기 실패", e);
-        }    }
-
+        }
+    }
 }

--- a/src/main/resources/static/css/cart.css
+++ b/src/main/resources/static/css/cart.css
@@ -1,0 +1,21 @@
+.cart-item td:first-child {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    justify-content: flex-start;
+}
+
+.cart-item td:first-child .book-title {
+    display: block;
+    max-width: 400px;  /* 도서 제목 노출 최대 길이 */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;  /* 긴 제목은 ... 처리 */
+    text-align: left;         /* 좌측 정렬 */
+}
+
+.summary {
+    position: sticky;
+    top: 20px;
+    align-self: flex-start;
+}

--- a/src/main/resources/static/js/book/book-detail.js
+++ b/src/main/resources/static/js/book/book-detail.js
@@ -84,7 +84,7 @@ $(document).ready(function() {
 
                 if (!response.ok) {
                     return response.json().then(function(errorData) {
-                        // 에러 응답을 throw
+                        // 에러 응답 throw
                         throw {
                             status: response.status,
                             data: errorData

--- a/src/main/resources/static/js/cart/cart.js
+++ b/src/main/resources/static/js/cart/cart.js
@@ -1,6 +1,31 @@
+// 배송 정책 데이터 (서버에서 전달받은 값)
+let deliveryPolicy = {
+    freeStandardAmount: 0,
+    deliveryFee: 0
+};
+
+// 페이지 로드 시 배송 정책 초기화
+function initDeliveryPolicy() {
+    const deliveryElement = document.getElementById('shipping');
+    if (deliveryElement && deliveryElement.hasAttribute('data-delivery-fee')) {
+        deliveryPolicy.deliveryFee = parseInt(deliveryElement.getAttribute('data-delivery-fee'));
+        deliveryPolicy.freeStandardAmount = parseInt(deliveryElement.getAttribute('data-free-amount'));
+    }
+}
+
 // 숫자 포맷팅 함수 (천단위 콤마)
 function formatNumber(num) {
     return num.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") + "원";
+}
+
+// 배송비 계산 함수
+function calculateShippingFee(subtotal) {
+    // 무료 배송 기준 금액 이상이면 배송비 0원
+    if (subtotal >= deliveryPolicy.freeStandardAmount) {
+        return 0;
+    }
+    // 그 외에는 배송비 부과
+    return deliveryPolicy.deliveryFee;
 }
 
 // 장바구니 총합 계산 함수
@@ -14,16 +39,36 @@ function calculateCartTotal() {
         subtotal += price * quantity;
     });
 
-    const shipping = 10;
-    const total = subtotal + shipping;
+    // 배송비 계산
+    const shippingFee = calculateShippingFee(subtotal);
+    const total = subtotal + shippingFee;
 
     // DOM 업데이트
     const subtotalElement = document.getElementById('subtotal');
+    const shippingElement = document.getElementById('shipping');
     const totalElement = document.getElementById('total');
 
     if (subtotalElement) {
         subtotalElement.textContent = formatNumber(subtotal);
     }
+
+    if (shippingElement) {
+        // 무료 배송일 경우 표시
+        if (shippingFee === 0) {
+            shippingElement.innerHTML = '<span class="text-success font-weight-bold">무료배송</span>';
+        } else {
+            shippingElement.textContent = formatNumber(shippingFee);
+
+            // 무료 배송까지 남은 금액 표시 (선택사항)
+            const remainingAmount = deliveryPolicy.freeStandardAmount - subtotal;
+            if (remainingAmount > 0) {
+                shippingElement.innerHTML = '<div class="text-right">' + formatNumber(shippingFee) +
+                    '<br><small class="text-muted">' +
+                    formatNumber(remainingAmount) + ' 더 담으면 무료배송</small></div>';
+            }
+        }
+    }
+
     if (totalElement) {
         totalElement.textContent = formatNumber(total);
     }
@@ -104,7 +149,6 @@ function plusButtons() {
                 });
         });
     });
-
 }
 
 // 수량 감소 버튼 이벤트
@@ -173,7 +217,6 @@ function minusButtons() {
             }
         });
     });
-
 }
 
 // 아이템 삭제 버튼 이벤트
@@ -235,8 +278,10 @@ function removeButtons() {
 
 // 주문하기 버튼 클릭 이벤트
 function orderButton() {
-    document.querySelector('.btn-order')
-        .addEventListener('click', function(e) {
+    const orderBtn = document.querySelector('.btn-order');
+
+    if (orderBtn) {
+        orderBtn.addEventListener('click', function(e) {
             e.preventDefault();
             e.stopPropagation();
 
@@ -252,7 +297,7 @@ function orderButton() {
             // 버튼 중복 클릭 방지
             orderButton.disabled = true;
             const originalHTML = orderButton.innerHTML;
-            orderButton.innerHTML = '<i class="fa fa-spinner fa-spin"></i>';
+            orderButton.innerHTML = '<i class="fa fa-spinner fa-spin"></i> 재고 확인 중...';
 
             // 장바구니 데이터 추출
             const orderItems = [];
@@ -260,12 +305,49 @@ function orderButton() {
             cartItems.forEach(item => {
                 const bookId = Number(item.getAttribute('data-book-id'));
                 const quantity = parseInt(item.getAttribute('data-quantity'));
+                const stock = parseInt(item.getAttribute('data-stock') || '0');
 
                 orderItems.push({
                     bookId: bookId,
-                    quantity: quantity
+                    quantity: quantity,
+                    stock: stock
                 });
             });
+
+            // 재고 검증
+            const insufficientStockItems = [];
+            orderItems.forEach(item => {
+                if (item.quantity > item.stock) {
+                    insufficientStockItems.push({
+                        bookId: item.bookId,
+                        requestedQty: item.quantity,
+                        availableStock: item.stock
+                    });
+                }
+            });
+
+            // 재고 부족한 상품이 있으면 주문 중단
+            if (insufficientStockItems.length > 0) {
+                let errorMessage = '재고가 부족한 상품이 있습니다:\n\n';
+
+                insufficientStockItems.forEach(item => {
+                    const itemElement = document.querySelector(`.cart-item[data-book-id="${item.bookId}"]`);
+                    const bookTitle = itemElement.querySelector('.book-title')?.textContent || '도서';
+
+                    errorMessage += `• ${bookTitle}\n`;
+                    errorMessage += `  요청 수량: ${item.requestedQty}개, 재고: ${item.availableStock}개\n\n`;
+                });
+
+                alert(errorMessage);
+
+                // 버튼 복원
+                orderButton.disabled = false;
+                orderButton.innerHTML = originalHTML;
+                return;
+            }
+
+            // 재고 검증 통과 시 주문 진행
+            orderButton.innerHTML = '<i class="fa fa-spinner fa-spin"></i> 주문 처리 중...';
 
             // 서버에 주문 생성 요청
             fetch('/orders', {
@@ -274,7 +356,10 @@ function orderButton() {
                     'Content-Type': 'application/json'
                 },
                 body: JSON.stringify({
-                    items: orderItems
+                    items: orderItems.map(item => ({
+                        bookId: item.bookId,
+                        quantity: item.quantity
+                    }))
                 })
             })
                 .then(function(response) {
@@ -285,12 +370,14 @@ function orderButton() {
                 .then(function(data) {
                     console.log('주문 요청 성공:', data);
 
-                    const encoded = encodeURIComponent(JSON.stringify(orderItems));
+                    const encoded = encodeURIComponent(JSON.stringify(orderItems.map(item => ({
+                        bookId: item.bookId,
+                        quantity: item.quantity
+                    }))));
+
+                    // 페이지 이동 (버튼은 복원하지 않음 - 이동될 때까지 로딩 상태 유지)
                     window.location.href = data.redirectUrl + `?items=${encoded}`;
 
-                    // 버튼 복원
-                    orderButton.disabled = false;
-                    orderButton.innerHTML = originalHTML;
                 })
                 .catch(function(error) {
                     console.error('에러 발생:', error);
@@ -301,14 +388,63 @@ function orderButton() {
                     orderButton.innerHTML = originalHTML;
                 });
         });
+    }
 }
 
+// 장바구니 비우기 버튼 이벤트
+function flushCartButton() {
+    const flushBtn = document.querySelector('.btn-flush-cart');
+
+    if (flushBtn) {
+        flushBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+
+            // 확인 대화상자
+            if (confirm('장바구니를 비우시겠습니까?')) {
+                // 버튼 비활성화 (중복 클릭 방지)
+                this.disabled = true;
+                const originalHTML = this.innerHTML;
+                this.innerHTML = '<i class="fa fa-spinner fa-spin"></i> 처리중...';
+
+                // 장바구니 비우기 API 호출
+                fetch('/carts/flush', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    }
+                })
+                    .then(function(response) {
+                        console.log('응답 상태:', response.status);
+
+                        if (!response.ok) {
+                            throw new Error('장바구니 비우기에 실패했습니다.');
+                        }
+
+                        // 성공 시 페이지 새로고침
+                        alert('장바구니가 비워졌습니다.');
+                        location.reload();
+                    })
+                    .catch(function(error) {
+                        console.error('Error:', error);
+                        alert('장바구니 비우기 중 오류가 발생했습니다.');
+
+                        // 버튼 복원
+                        flushBtn.disabled = false;
+                        flushBtn.innerHTML = originalHTML;
+                    });
+            }
+        });
+    }
+}
 
 // 페이지 로드 시 초기화
 document.addEventListener('DOMContentLoaded', function() {
+    initDeliveryPolicy();   // 배송 정책 초기화
     calculateCartTotal();   // 총합 계산
     plusButtons();          // 수량 증가 버튼
     minusButtons();         // 수량 감소 버튼
     removeButtons();        // 삭제 버튼
     orderButton();          // 주문 버튼
+    flushCartButton();      // 장바구니 비우기 버튼
 });

--- a/src/main/resources/templates/book/book-category-list.html
+++ b/src/main/resources/templates/book/book-category-list.html
@@ -331,6 +331,7 @@
                                 errorMessage = error.message;
                             }
 
+                            // Error Message 예시 1 : "해당 도서의 재고가 부족합니다."
                             alert(errorMessage);
 
                             // 에러 발생 시 버튼 복원

--- a/src/main/resources/templates/cart/cart.html
+++ b/src/main/resources/templates/cart/cart.html
@@ -6,6 +6,8 @@
 </head>
 
 <section>
+    <link rel="stylesheet" th:href="@{/css/cart.css}"/>
+
     <!-- Breadcrumb Start -->
     <div class="container-fluid">
         <div class="row px-xl-5">
@@ -24,6 +26,15 @@
     <div class="container-fluid">
         <div class="row px-xl-5">
             <div class="col-lg-8 table-responsive mb-5">
+                <!-- 장바구니 비우기 버튼 추가 -->
+                <div class="d-flex justify-content-between align-items-center mb-3"
+                     th:if="${cart != null and cart.items != null and !#lists.isEmpty(cart.items)}">
+                    <h5 class="mb-0">장바구니 목록</h5>
+                    <button class="btn btn-outline-danger btn-sm btn-flush-cart">
+                        <i class="fa fa-trash mr-1"></i>장바구니 비우기
+                    </button>
+                </div>
+
                 <table class="table table-light table-borderless table-hover text-center mb-0" id="cartTable">
                     <thead class="thead-dark">
                     <tr>
@@ -39,10 +50,11 @@
                         <tr th:each="item : ${cart.items}" class="cart-item"
                             th:attr="data-book-id=${item.bookId},
                                      data-price=${item.bookSalesPrice},
-                                     data-quantity=${item.quantity}">
+                                     data-quantity=${item.quantity}",
+                                     data-stock=${item.bookStock}>
                             <td class="align-middle">
-                                <img th:src="${item.bookImageUrl}" alt="" style="width: 50px;">
-                                <span th:text="${item.bookTitle}">Product Name</span>
+                                <img class="book-image" th:src="${item.bookImageUrl}" alt="" style="width: 50px;">
+                                <span class="book-title" th:text="${item.bookTitle}">Product Name</span>
                             </td>
 
                             <td class="align-middle">
@@ -58,7 +70,7 @@
                                           th:text="${#numbers.formatInteger(item.bookSalesPrice, 1, 'COMMA')} + '원'">17,500원</span>
                                         <!-- 할인율 -->
                                         <small class="text-danger" style="font-size: 0.8em;">
-                                            <span th:text="${#numbers.formatInteger((item.bookPrice - item.bookSalesPrice) * 100 / item.bookPrice, 0)} + '%'">12%</span>
+                                            <span th:text="${T(java.lang.Math).round((item.bookPrice - item.bookSalesPrice) * 100.0 / item.bookPrice)} + '%'">12%</span>
                                             <span th:text="'(-' + ${#numbers.formatInteger(item.bookPrice - item.bookSalesPrice, 1, 'COMMA')} + '원)'">(-2,500원)</span>
                                         </small>
                                     </div>
@@ -114,14 +126,12 @@
                 </table>
             </div>
 
-            <div class="col-lg-4">
-                <!-- TODO: STICKY 처리 필요 -->
+            <div class="col-lg-4 summary">
                 <h5 class="section-title position-relative text-uppercase mb-3">
                     <span class="bg-secondary pr-3">Cart Summary</span>
                 </h5>
                 <div class="bg-light p-30 mb-5">
                     <!-- 장바구니에 아이템이 있을 때만 요약 정보 표시 -->
-                    <!-- TODO: 배송비 처리 필요 -->
                     <div id="cartSummary" th:if="${cart != null and cart.items != null and !#lists.isEmpty(cart.items)}">
                         <div class="border-bottom pb-2">
                             <div class="d-flex justify-content-between mb-3">
@@ -130,7 +140,11 @@
                             </div>
                             <div class="d-flex justify-content-between">
                                 <h6 class="font-weight-medium">Shipping</h6>
-                                <h6 class="font-weight-medium" id="shipping">10원</h6>
+                                <h6 class="font-weight-medium" id="shipping"
+                                    th:attr="data-delivery-fee=${currentDelivery.deliveryFee},
+                                            data-free-amount=${currentDelivery.freeStandardAmount}">
+                                    0원
+                                </h6>
                             </div>
                         </div>
                         <div class="pt-2">

--- a/src/main/resources/templates/layout/header.html
+++ b/src/main/resources/templates/layout/header.html
@@ -71,7 +71,6 @@
                             <a href="/books" class="nav-item nav-link">전체 도서</a>
                             <a href="/ranking" class="nav-item nav-link">랭킹</a>
                             <a sec:authorize="isAuthenticated()" href="/coupon-box" class="nav-item nav-link">쿠폰함</a>
-                            <a href="/orders/history" class="nav-item nav-link">주문 내역</a>
 
                         </div>
 
@@ -80,6 +79,7 @@
                                 <div sec:authorize="!isAuthenticated()" class="d-flex align-items-center">
                                     <a href="/login" class="nav-item nav-link me-3">로그인</a>
                                     <a href="/signup" class="nav-item nav-link me-3">회원가입</a>
+                                    <a href="/orders/history" class="nav-item nav-link">주문 내역</a>
                                 </div>
 
                                 <div sec:authorize="isAuthenticated()" class="d-flex align-items-center">
@@ -88,6 +88,7 @@
                                     <form action="/logout" method="post" style="display: inline;">
                                         <button type="submit" class="nav-item nav-link border-0 bg-transparent me-3" style="cursor: pointer;">로그아웃</button>
                                     </form>
+                                    <a href="/orders/history" class="nav-item nav-link">주문 내역</a>
                                 </div>
                                 <a href="#" class="btn px-0 me-3">
                                     <i class="fas fa-heart text-primary"></i>


### PR DESCRIPTION
## 🔥 연관 이슈

## 📝 작업 요약

> 장바구니 화면 및 메인 화면 수정

## ⏰ 소요 시간

> 1일 

## 🔎 작업 상세 설명

- 비회원 장바구니 첫 담기 / 조회 시 오류 수정
-  장바구니 화면 스타일 조정
    - 장바구니 아이템 전체 비우기 기능 추가
    - 도서 제목 최대 길이 조정
    - 도서 할인율 계산 로직 수정 (도서 상세 화면의 도서 할인율 계산 로직과 동일하도록 수정)
- 장바구니 화면 Summary
    - Sticky UI 적용
    - 배송비 표현 및 로직 적용
- 메인 화면
    - 주문내역 링크/버튼 위치 이동

## 🌟 논의 사항
