### PR TITLE
feat: 회원 관리자 페이지 구현

### DIFF
--- a/src/main/java/shop/chaekmate/front/auth/config/SecurityConfig.java
+++ b/src/main/java/shop/chaekmate/front/auth/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                         // 관리자 로그인 페이지는 누구나 접근 가능
                         .requestMatchers("/admin/login").permitAll()
                         // 관리자 페이지는 ADMIN 권한 필요
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/admin/**").permitAll()
                         // 비회원도 접근 되는 곳들
                         .requestMatchers("/css/**", "/js/**", "/img/**", "/lib/**",
                                 "/favicon.ico","/mail/**", "/scss/**").permitAll() // resources/static 아래 경로들 추가
@@ -52,7 +52,7 @@ public class SecurityConfig {
                         // 회원 전용
                         .requestMatchers("/mypage/**", "/logout").authenticated()
                         // 나머지는 인증 필요
-                        .anyRequest().authenticated())
+                        .anyRequest().permitAll())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(
                                 (request, response, authException) -> response.sendRedirect("/login")))

--- a/src/main/java/shop/chaekmate/front/auth/config/SecurityConfig.java
+++ b/src/main/java/shop/chaekmate/front/auth/config/SecurityConfig.java
@@ -32,7 +32,7 @@ public class SecurityConfig {
                         // 관리자 로그인 페이지는 누구나 접근 가능
                         .requestMatchers("/admin/login").permitAll()
                         // 관리자 페이지는 ADMIN 권한 필요
-                        .requestMatchers("/admin/**").permitAll()
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
                         // 비회원도 접근 되는 곳들
                         .requestMatchers("/css/**", "/js/**", "/img/**", "/lib/**",
                                 "/favicon.ico","/mail/**", "/scss/**").permitAll() // resources/static 아래 경로들 추가
@@ -52,7 +52,7 @@ public class SecurityConfig {
                         // 회원 전용
                         .requestMatchers("/mypage/**", "/logout").authenticated()
                         // 나머지는 인증 필요
-                        .anyRequest().permitAll())
+                        .anyRequest().authenticated())
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint(
                                 (request, response, authException) -> response.sendRedirect("/login")))

--- a/src/main/java/shop/chaekmate/front/member/adaptor/AdminMemberAdaptor.java
+++ b/src/main/java/shop/chaekmate/front/member/adaptor/AdminMemberAdaptor.java
@@ -1,0 +1,24 @@
+package shop.chaekmate.front.member.adaptor;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.*;
+import shop.chaekmate.front.common.CommonResponse;
+import shop.chaekmate.front.member.dto.response.MemberResponse;
+
+import java.util.List;
+
+@FeignClient(name = "admin-member-adaptor", url = "${chaekmate.gateway.url}")
+public interface AdminMemberAdaptor {
+
+    @GetMapping("/admin/members")
+    CommonResponse<List<MemberResponse>> getMembers(@RequestParam("status") String status);
+
+    @GetMapping("/admin/members/{memberId}")
+    CommonResponse<MemberResponse> getMember(@PathVariable Long memberId);
+
+    @DeleteMapping("/admin/members/{memberId}")
+    CommonResponse<Void> deleteMember(@PathVariable Long memberId);
+
+    @PostMapping("/admin/members/{memberId}/restore")
+    CommonResponse<Void> restoreMember(@PathVariable Long memberId);
+}

--- a/src/main/java/shop/chaekmate/front/member/controller/AdminMemberController.java
+++ b/src/main/java/shop/chaekmate/front/member/controller/AdminMemberController.java
@@ -1,0 +1,63 @@
+package shop.chaekmate.front.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+import shop.chaekmate.front.member.dto.response.MemberResponse;
+import shop.chaekmate.front.member.service.AdminMemberService;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class AdminMemberController {
+
+    private static final String REDIRECT_MEMBERS = "redirect:/admin/members";
+
+    private final AdminMemberService adminMemberService;
+
+    @GetMapping("/admin/members")
+    public String memberManagementView(@RequestParam(defaultValue = "ACTIVE") String status,
+                                       Model model) {
+        List<MemberResponse> members = "DELETED".equalsIgnoreCase(status)
+                ? adminMemberService.getDeletedMembers()
+                : adminMemberService.getActiveMembers();
+
+        model.addAttribute("members", members);
+        model.addAttribute("status", status.toUpperCase());
+        return "admin/member/member-management";
+    }
+
+    @PostMapping("/admin/members/{memberId}")
+    public String deleteMember(@PathVariable Long memberId,
+                               @RequestParam(defaultValue = "ACTIVE") String status,
+                               RedirectAttributes redirectAttributes) {
+        try {
+            adminMemberService.deleteMember(memberId);
+            redirectAttributes.addFlashAttribute("msg", "회원이 탈퇴 처리되었습니다.");
+        } catch (RuntimeException e) {
+            redirectAttributes.addFlashAttribute("error", "회원 탈퇴 처리에 실패했습니다.");
+        }
+        redirectAttributes.addAttribute("status", status.toUpperCase());
+        return REDIRECT_MEMBERS;
+    }
+
+    @PostMapping("/admin/members/{memberId}/restore")
+    public String restoreMember(@PathVariable Long memberId,
+                                @RequestParam(defaultValue = "DELETED") String status,
+                                RedirectAttributes redirectAttributes) {
+        try {
+            adminMemberService.restoreMember(memberId);
+            redirectAttributes.addFlashAttribute("msg", "회원이 복구되었습니다.");
+        } catch (RuntimeException e) {
+            redirectAttributes.addFlashAttribute("error", "회원 복구에 실패했습니다.");
+        }
+        redirectAttributes.addAttribute("status", status.toUpperCase());
+        return REDIRECT_MEMBERS;
+    }
+}

--- a/src/main/java/shop/chaekmate/front/member/dto/response/MemberGradeResponse.java
+++ b/src/main/java/shop/chaekmate/front/member/dto/response/MemberGradeResponse.java
@@ -1,7 +1,0 @@
-package shop.chaekmate.front.member.dto.response;
-
-public record MemberGradeResponse(
-        String name,
-        Byte pointRate
-) {
-}

--- a/src/main/java/shop/chaekmate/front/member/dto/response/MemberResponse.java
+++ b/src/main/java/shop/chaekmate/front/member/dto/response/MemberResponse.java
@@ -1,7 +1,15 @@
 package shop.chaekmate.front.member.dto.response;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 public record MemberResponse(
+        Long id,
+        String loginId,
         String name,
         String phone,
-        String email) {
-}
+        String email,
+        LocalDate birthDate,
+        String platformType,
+        LocalDateTime lastLoginAt
+) {}

--- a/src/main/java/shop/chaekmate/front/member/service/AdminMemberService.java
+++ b/src/main/java/shop/chaekmate/front/member/service/AdminMemberService.java
@@ -1,0 +1,31 @@
+package shop.chaekmate.front.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import shop.chaekmate.front.member.adaptor.AdminMemberAdaptor;
+import shop.chaekmate.front.member.dto.response.MemberResponse;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AdminMemberService {
+
+    private final AdminMemberAdaptor adminMemberAdaptor;
+
+    public List<MemberResponse> getActiveMembers() {
+        return adminMemberAdaptor.getMembers("ACTIVE").data();
+    }
+
+    public List<MemberResponse> getDeletedMembers() {
+        return adminMemberAdaptor.getMembers("DELETED").data();
+    }
+
+    public void deleteMember(Long memberId) {
+        adminMemberAdaptor.deleteMember(memberId);
+    }
+
+    public void restoreMember(Long memberId) {
+        adminMemberAdaptor.restoreMember(memberId);
+    }
+}

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -9724,3 +9724,30 @@ a.text-dark:hover, a.text-dark:focus {
     background-color: #e9ecef;
 }
 
+.status-select-wrapper {
+  background: #fff;
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  padding: 6px 12px;
+  display: flex;
+  align-items: center;
+}
+
+.status-select {
+  border: none !important;
+  box-shadow: none !important;
+  font-size: 0.9rem;
+  padding-left: 0;
+  padding-right: 0;
+  width: auto;
+  min-width: 120px;
+  background-color: transparent !important;
+  cursor: pointer;
+}
+
+.status-select:focus {
+  outline: none !important;
+  box-shadow: none !important;
+}
+
+

--- a/src/main/resources/templates/admin/layout/admin-siderbar.html
+++ b/src/main/resources/templates/admin/layout/admin-siderbar.html
@@ -5,6 +5,8 @@
         <a class="nav-item nav-link" th:href="@{/admin}">대시보드</a>
         <a class="nav-item nav-link" th:href="@{/admin/books}">도서 관리</a>
         <a class="nav-item nav-link" th:href="@{/admin/categories}">카테고리 관리</a>
+        <a class="nav-item nav-link" th:href="@{/admin/members}">회원 관리</a>
+        <a class="nav-item nav-link" th:href="@{/admin/grades}">등급 정책 관리</a>
         <a class="nav-item nav-link" th:href="@{/admin/tags}">태그 관리</a>
         <a class="nav-item nav-link" th:href="@{/admin/coupons}">쿠폰 관리</a>
         <a class="nav-item nav-link" th:href="@{/admin/point-policies}">포인트 정책 관리</a>

--- a/src/main/resources/templates/admin/member/member-management.html
+++ b/src/main/resources/templates/admin/member/member-management.html
@@ -14,18 +14,20 @@
                                 <label for="status" class="col-form-label">회원 상태</label>
                             </div>
                             <div class="col-auto">
-                                <select id="status" name="status"
-                                        class="form-select d-inline-block w-auto"
-                                        onchange="this.form.submit()">
-                                    <option value="ACTIVE"
-                                            th:selected="${status == null or status == 'ACTIVE'}">
-                                        활성 회원
-                                    </option>
-                                    <option value="DELETED"
-                                            th:selected="${status == 'DELETED'}">
-                                        탈퇴 회원
-                                    </option>
-                                </select>
+                                <div class="status-select-wrapper">
+                                    <select id="status" name="status"
+                                            class="form-select form-select-sm status-select"
+                                            onchange="this.form.submit()">
+                                        <option value="ACTIVE"
+                                                th:selected="${status == null or status == 'ACTIVE'}">
+                                            활성 회원
+                                        </option>
+                                        <option value="DELETED"
+                                                th:selected="${status == 'DELETED'}">
+                                            탈퇴 회원
+                                        </option>
+                                    </select>
+                                </div>
                             </div>
                         </div>
                     </form>
@@ -66,7 +68,7 @@
                             <form th:if="${status != 'DELETED'}"
                                   th:action="@{/admin/members/{id}(id=${member.id()})}"
                                   method="post" class="d-inline-block ml-1">
-                                <input type="hidden" name="_method" value="delete"/>
+                                <input type="hidden" name="_method" value="post"/>
                                 <button type="submit" class="btn btn-sm btn-danger">
                                     탈퇴
                                 </button>

--- a/src/main/resources/templates/admin/member/member-management.html
+++ b/src/main/resources/templates/admin/member/member-management.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ko"
+      th:replace="~{admin/layout/admin-layout :: html(~{::section})}">
+<section>
+    <div class="container-fluid">
+        <div class="row px-xl-5">
+            <div class="col-12">
+                <h2 class="h2 font-weight-bold text-dark mb-4">회원 관리 대시보드</h2>
+
+                <div class="mb-4">
+                    <form method="get" class="d-flex align-items-center">
+                        <div class="row g-2 align-items-center">
+                            <div class="col-auto">
+                                <label for="status" class="col-form-label">회원 상태</label>
+                            </div>
+                            <div class="col-auto">
+                                <select id="status" name="status"
+                                        class="form-select d-inline-block w-auto"
+                                        onchange="this.form.submit()">
+                                    <option value="ACTIVE"
+                                            th:selected="${status == null or status == 'ACTIVE'}">
+                                        활성 회원
+                                    </option>
+                                    <option value="DELETED"
+                                            th:selected="${status == 'DELETED'}">
+                                        탈퇴 회원
+                                    </option>
+                                </select>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+
+                <div th:if="${#lists.isEmpty(members)}" class="alert alert-info">
+                    회원이 없습니다.
+                </div>
+
+                <table class="table table-bordered text-center" th:unless="${#lists.isEmpty(members)}">
+                    <thead class="thead-dark">
+                    <tr>
+                        <th>ID</th>
+                        <th>로그인 ID</th>
+                        <th>이름</th>
+                        <th>이메일</th>
+                        <th>전화번호</th>
+                        <th>생년월일</th>
+                        <th>플랫폼</th>
+                        <th>마지막 로그인</th>
+                        <th>상태</th>
+                        <th>관리</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="member : ${members}">
+                        <td th:text="${member.id()}"></td>
+                        <td th:text="${member.loginId()}"></td>
+                        <td th:text="${member.name()}"></td>
+                        <td th:text="${member.email()}"></td>
+                        <td th:text="${member.phone()}"></td>
+                        <td th:text="${member.birthDate()}"></td>
+                        <td th:text="${member.platformType()}"></td>
+                        <td th:text="${member.lastLoginAt()}"></td>
+                        <td th:text="${status == 'DELETED' ? '탈퇴' : '활성'}"></td>
+                        <td class="d-flex justify-content-center gap-1">
+
+                            <form th:if="${status != 'DELETED'}"
+                                  th:action="@{/admin/members/{id}(id=${member.id()})}"
+                                  method="post" class="d-inline-block ml-1">
+                                <input type="hidden" name="_method" value="delete"/>
+                                <button type="submit" class="btn btn-sm btn-danger">
+                                    탈퇴
+                                </button>
+                            </form>
+
+                            <form th:if="${status == 'DELETED'}"
+                                  th:action="@{/admin/members/{id}/restore(id=${member.id()})}"
+                                  method="post" class="d-inline-block ml-1">
+                                <button type="submit" class="btn btn-sm btn-success">
+                                    복구
+                                </button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+
+            </div>
+        </div>
+    </div>
+</section>
+</html>


### PR DESCRIPTION
## 🔥 연관 이슈

close: #

## 📝 작업 요약

활성/탈퇴 회원 목록 조회 및 상태 변경

## ⏰ 소요 시간

3h

## 🔎 작업 상세 설명

- 활성/탈퇴 회원 목록 조회
- 탈퇴 회원 복구
- 회원 탈퇴 처리

## 🌟 논의 사항

동료들과 이야기 해보고 싶은 부분을 적어주세요.
